### PR TITLE
fix: No scopes provided on App creation

### DIFF
--- a/app/src/main/java/tech/buildrun/service/AppService.java
+++ b/app/src/main/java/tech/buildrun/service/AppService.java
@@ -43,6 +43,10 @@ public class AppService {
     }
 
     private Set<ScopeEntity> fetchScopesByName(Set<String> scopes) {
+        if (scopes == null || scopes.isEmpty()) {
+            throw new CreateEntityException("Create App Exception", "No scopes provided");
+        }
+
         Set<ScopeEntity> scopeEntities = new HashSet<>();
 
         scopes.forEach((scopeName) -> {


### PR DESCRIPTION
Quando crio uma App com scopes nulos ou vazios retorno uma exceção tratada

`{
    "type": "about:blank",
    "title": "Create App Exception",
    "detail": "No scopes provided",
    "status": 422,
    "invalidParams": null
}`