### PR TITLE
Associando "lock" ao S3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ~1.0
+          terraform_version: 1.10.1
           terraform_wrapper: false
 
       - name: Verify Terraform setup
@@ -374,7 +374,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ~1.0
+          terraform_version: 1.10.1
           terraform_wrapper: false
 
       - name: Terraform Initialization and Planning

--- a/terraform/backend-config/dev.hcl
+++ b/terraform/backend-config/dev.hcl
@@ -4,7 +4,7 @@ bucket         = "terraform-311141562939-statefile"
 key            = "dev/terraform.tfstate"
 region         = "us-east-2"
 encrypt        = true
-dynamodb_table = "311141562939-terraform-lock"
+use_lockfile = true
 
 # Optional: Enable versioning and server-side encryption
 # These settings should be configured on the S3 bucket itself

--- a/terraform/backend-config/prod.hcl
+++ b/terraform/backend-config/prod.hcl
@@ -4,7 +4,7 @@ bucket         = "ticketmaster-terraform-state-prod"
 key            = "prod/terraform.tfstate"
 region         = "us-east-2"
 encrypt        = true
-dynamodb_table = "ticketmaster-terraform-locks-prod"
+use_lockfile = true
 
 # Optional: Enable versioning and server-side encryption
 # These settings should be configured on the S3 bucket itself

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
 # Main Terraform configuration for TicketMaster CI/CD Infrastructure
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10.1"
   
   required_providers {
     aws = {


### PR DESCRIPTION
## 🌿 Nome da branch

```bash
change-lockId-to-s3
```

## 📌 Título do Pull Request

```text
Associando "lock" ao S3
```

## 📝 Descrição do Pull Request

### Contexto

Durante live de 24/02/2026 foi levantando um ponto de possível melhoria direcionando o lock do dynamoDB para o S3.

### Melhoria

Atualizar versão do terraform para "1.10.1" e ajustar pontos relacionados;
              Alterar referencia ao dynamoDB por "lock" no s3 (use_lockfile = true).

### Impacto
- Inibe a necessidade do dynamoDB e possíveis custos relacionados

### Branch base/destino (develop):⚠️
- Branch para ajuste foi originada a partir de  develop
            
### Teste
<img width="1401" height="471" alt="image" src="https://github.com/user-attachments/assets/2f5b652b-8cda-4f88-90e4-6521d627a450" />

