### PR TITLE
fix(terraform): bump ADOT collector image from v0.43.4 to v0.48.0

### DIFF
--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -180,7 +180,7 @@ variable "autoscaling_scale_out_cooldown" {
 variable "adot_collector_image" {
   description = "Docker image for the AWS Distro for OpenTelemetry (ADOT) Collector sidecar"
   type        = string
-  default     = "amazon/aws-otel-collector:v0.43.4"
+  default     = "amazon/aws-otel-collector:v0.48.0"
 }
 
 variable "latency_p99_threshold_seconds" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -216,9 +216,9 @@ variable "ecs_autoscaling_scale_out_cooldown" {
 
 # Observability — 4 Golden Signals
 variable "adot_collector_image" {
-  description = "Docker image for the ADOT Collector sidecar (e.g. amazon/aws-otel-collector:v0.43.4)"
+  description = "Docker image for the ADOT Collector sidecar (e.g. amazon/aws-otel-collector:v0.48.0)"
   type        = string
-  default     = "amazon/aws-otel-collector:v0.43.4"
+  default     = "amazon/aws-otel-collector:v0.48.0"
 }
 
 variable "latency_p99_threshold_seconds" {


### PR DESCRIPTION
v0.43.4 is no longer available on Docker Hub causing ECS task pull failures.