### PR TITLE
fix(otel): fix ADOT collector batch config and Quarkus metrics exporter

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,9 +1,13 @@
 # Application identity (sets OTel service.name resource attribute)
 quarkus.application.name=ticketmaster
 
-# OpenTelemetry — export metrics via OTLP gRPC to ADOT Collector sidecar
-quarkus.otel.metrics.exporter=otlp
-quarkus.otel.exporter.otlp.metrics.endpoint=${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:http://localhost:4317}
+# OpenTelemetry — export metrics via Quarkus Vert.x HTTP sender to ADOT Collector sidecar
+# Use exporter=cdi so Quarkus selects its own VertxHttpMetricsExporter CDI bean;
+# exporter=otlp bypasses Quarkus and falls through to the OTel SDK provider which requires
+# an external HttpSenderProvider (opentelemetry-exporter-sender-okhttp/jdk) not on the classpath.
+quarkus.otel.metrics.exporter=cdi
+quarkus.otel.exporter.otlp.metrics.protocol=http/protobuf
+quarkus.otel.exporter.otlp.metrics.endpoint=${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:http://localhost:4318}
 # Disable traces until distributed tracing is adopted (non-goal)
 quarkus.otel.traces.exporter=none
 # Tag metrics with deployment environment for CloudWatch dimension filtering

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,14 @@
 services:
+  otel-collector:
+    image: amazon/aws-otel-collector:v0.48.0
+    container_name: ticketmaster-otel-collector
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config-local.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
   localstack:
     container_name: "ticketmaster-localstack"
     image: localstack/localstack

--- a/docker/otel-collector-config-local.yaml
+++ b/docker/otel-collector-config-local.yaml
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 60s
+    send_batch_size: 100
+    send_batch_max_size: 1000
+
+exporters:
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -320,7 +320,7 @@ resource "aws_ecs_task_definition" "app" {
         },
         {
           name  = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
-          value = "http://localhost:4317"
+          value = "http://localhost:4318"
         }
       ]
 

--- a/terraform/modules/ecs/otel-collector-config.yaml.tftpl
+++ b/terraform/modules/ecs/otel-collector-config.yaml.tftpl
@@ -3,10 +3,13 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:
     timeout: 60s
+    send_batch_size: 100
     send_batch_max_size: 1000
 
 exporters:


### PR DESCRIPTION
- ADOT collector: add send_batch_size=100 (must be <= send_batch_max_size=1000)
- ADOT collector: add HTTP receiver on 4318 alongside gRPC on 4317
- Quarkus: switch quarkus.otel.metrics.exporter from otlp to cdi so that Quarkus selects its own VertxHttpMetricsExporter CDI bean instead of the standard OTel SDK OtlpMetricExporterProvider which requires an external HttpSenderProvider not on the classpath
- Quarkus: use http/protobuf protocol on port 4318 (instead of gRPC 4317)
- Terraform: update OTLP endpoint env var from port 4317 to 4318
- Docker: add ADOT collector service to docker-compose for local testing